### PR TITLE
Fix MathBuilder's operator parsing order and add support to local multiline MoLang variables

### DIFF
--- a/mclib/src/main/java/com/eliotlash/mclib/math/MathBuilder.java
+++ b/mclib/src/main/java/com/eliotlash/mclib/math/MathBuilder.java
@@ -288,56 +288,96 @@ public class MathBuilder
         }
 
         /* Any other math expression */
-        int firstOp = -1;
-        int secondOp = -1;
+        int lastOp = this.seekLastOperator(symbols);
+        int op = lastOp;
 
-        /* Find next two operators' indices */
-        for (int i = 0; i < size; i++)
+        while (op != -1)
+        {
+            int leftOp = this.seekLastOperator(symbols, op - 1);
+
+            if (leftOp != -1)
+            {
+                Operation left = this.operationForOperator((String) symbols.get(leftOp));
+                Operation right = this.operationForOperator((String) symbols.get(op));
+
+                if (right.value > left.value)
+                {
+                    IValue leftValue = this.parseSymbols(symbols.subList(0, leftOp));
+                    IValue rightValue = this.parseSymbols(symbols.subList(leftOp + 1, size));
+
+                    return new Operator(left, leftValue, rightValue);
+                }
+                else if (left.value > right.value)
+                {
+                    Operation initial = this.operationForOperator((String) symbols.get(lastOp));
+
+                    if (initial.value < left.value)
+                    {
+                        IValue leftValue = this.parseSymbols(symbols.subList(0, lastOp));
+                        IValue rightValue = this.parseSymbols(symbols.subList(lastOp + 1, size));
+
+                        return new Operator(initial, leftValue, rightValue);
+                    }
+
+                    IValue leftValue = this.parseSymbols(symbols.subList(0, op));
+                    IValue rightValue = this.parseSymbols(symbols.subList(op + 1, size));
+
+                    return new Operator(right, leftValue, rightValue);
+                }
+            }
+
+            op = leftOp;
+        }
+
+        Operation operation = this.operationForOperator((String) symbols.get(lastOp));
+
+        return new Operator(operation, this.parseSymbols(symbols.subList(0, lastOp)), this.parseSymbols(symbols.subList(lastOp + 1, size)));
+    }
+
+    protected int seekLastOperator(List<Object> symbols)
+    {
+        return this.seekLastOperator(symbols, symbols.size() - 1);
+    }
+
+    /**
+     * Find the index of the first operator
+     */
+    protected int seekLastOperator(List<Object> symbols, int offset)
+    {
+        for (int i = offset; i >= 0; i--)
         {
             Object o = symbols.get(i);
 
             if (this.isOperator(o))
             {
-                if (firstOp == -1)
-                {
-                    firstOp = i;
-                }
-                else
-                {
-                    secondOp = i;
-                    break;
-                }
+                return i;
             }
         }
 
-        /* And finally construct the math operation */
-        Operation op = this.operationForOperator((String) symbols.get(firstOp));
+        return -1;
+    }
 
-        if (secondOp == -1)
+    protected int seekFirstOperator(List<Object> symbols)
+    {
+        return this.seekFirstOperator(symbols, 0);
+    }
+
+    /**
+     * Find the index of the first operator
+     */
+    protected int seekFirstOperator(List<Object> symbols, int offset)
+    {
+        for (int i = offset, size = symbols.size(); i < size; i++)
         {
-            IValue left = this.parseSymbols(symbols.subList(0, firstOp));
-            IValue right = this.parseSymbols(symbols.subList(firstOp + 1, MathUtils.clamp(firstOp + 3, 0, size)));
+            Object o = symbols.get(i);
 
-            return new Operator(op, left, right);
-        }
-        else if (secondOp > firstOp)
-        {
-            Operation compareTo = this.operationForOperator((String) symbols.get(secondOp));
-            IValue left = this.parseSymbols(symbols.subList(0, firstOp));
-
-            if (compareTo.value > op.value)
+            if (this.isOperator(o))
             {
-                return new Operator(op, left, this.parseSymbols(symbols.subList(firstOp + 1, size)));
-            }
-            else
-            {
-                IValue right = this.parseSymbols(symbols.subList(firstOp + 1, secondOp));
-
-                return new Operator(compareTo, new Operator(op, left, right), this.parseSymbols(symbols.subList(secondOp + 1, size)));
+                return i;
             }
         }
 
-        throw new Exception("Given symbols couldn't be parsed! " + symbols);
+        return -1;
     }
 
     /**

--- a/molang/src/main/java/com/eliotlash/molang/expressions/MolangMultiStatement.java
+++ b/molang/src/main/java/com/eliotlash/molang/expressions/MolangMultiStatement.java
@@ -1,14 +1,18 @@
 package com.eliotlash.molang.expressions;
 
+import com.eliotlash.mclib.math.Variable;
 import com.eliotlash.molang.MolangParser;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
 
 public class MolangMultiStatement extends MolangExpression
 {
 	public List<MolangExpression> expressions = new ArrayList<MolangExpression>();
+	public Map<String, Variable> locals = new HashMap<String, Variable>();
 
 	public MolangMultiStatement(MolangParser context)
 	{
@@ -36,6 +40,11 @@ public class MolangMultiStatement extends MolangExpression
 		for (MolangExpression expression : this.expressions)
 		{
 			builder.add(expression.toString());
+
+			if (expression instanceof MolangValue && ((MolangValue) expression).returns)
+			{
+				break;
+			}
 		}
 
 		return builder.toString();

--- a/molang/src/main/java/com/eliotlash/molang/expressions/MolangValue.java
+++ b/molang/src/main/java/com/eliotlash/molang/expressions/MolangValue.java
@@ -5,12 +5,11 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.eliotlash.molang.MolangParser;
 import com.eliotlash.mclib.math.Constant;
-import com.eliotlash.mclib.math.IValue;
 
 public class MolangValue extends MolangExpression
 {
 	public IValue value;
-	public boolean addReturn;
+	public boolean returns;
 
 	public MolangValue(MolangParser context, IValue value)
 	{
@@ -21,7 +20,7 @@ public class MolangValue extends MolangExpression
 
 	public MolangExpression addReturn()
 	{
-		this.addReturn = true;
+		this.returns = true;
 
 		return this;
 	}
@@ -35,7 +34,7 @@ public class MolangValue extends MolangExpression
 	@Override
 	public String toString()
 	{
-		return (this.addReturn ? MolangParser.RETURN : "") + this.value.toString();
+		return (this.returns ? MolangParser.RETURN : "") + this.value.toString();
 	}
 
 	@Override

--- a/particlelib/src/main/java/com/eliotlash/particlelib/particles/BedrockScheme.java
+++ b/particlelib/src/main/java/com/eliotlash/particlelib/particles/BedrockScheme.java
@@ -1,5 +1,6 @@
 package com.eliotlash.particlelib.particles;
 
+import com.eliotlash.mclib.math.Variable;
 import com.eliotlash.particlelib.mcwrapper.ResourceLocation;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -62,7 +63,7 @@ public class BedrockScheme
 	private boolean factory;
 
 	/* MoLang integration */
-	public MolangParser parser = new MolangParser();
+	public MolangParser parser;
 
 	public static BedrockScheme parse(String json)
 	{
@@ -86,6 +87,25 @@ public class BedrockScheme
 	public static BedrockScheme dupe(BedrockScheme scheme)
 	{
 		return parse(toJson(scheme));
+	}
+
+	public BedrockScheme()
+	{
+		this.parser = new MolangParser();
+
+		/* Default variables */
+		this.parser.register(new Variable("variable.particle_age", 0));
+		this.parser.register(new Variable("variable.particle_lifetime", 0));
+		this.parser.register(new Variable("variable.particle_random_1", 0));
+		this.parser.register(new Variable("variable.particle_random_2", 0));
+		this.parser.register(new Variable("variable.particle_random_3", 0));
+		this.parser.register(new Variable("variable.particle_random_4", 0));
+		this.parser.register(new Variable("variable.emitter_age", 0));
+		this.parser.register(new Variable("variable.emitter_lifetime", 0));
+		this.parser.register(new Variable("variable.emitter_random_1", 0));
+		this.parser.register(new Variable("variable.emitter_random_2", 0));
+		this.parser.register(new Variable("variable.emitter_random_3", 0));
+		this.parser.register(new Variable("variable.emitter_random_4", 0));
 	}
 
 	public BedrockScheme factory(boolean factory)

--- a/particlelib/src/main/java/com/eliotlash/particlelib/particles/emitter/BedrockEmitter.java
+++ b/particlelib/src/main/java/com/eliotlash/particlelib/particles/emitter/BedrockEmitter.java
@@ -171,7 +171,7 @@ public abstract class BedrockEmitter
 	{
 		try
 		{
-			this.variables.put(name, this.scheme.parser.parseNoRegister(expression));
+			this.variables.put(name, this.scheme.parser.parse(expression));
 		}
 		catch (Exception e)
 		{}


### PR DESCRIPTION
A couple of fixes I spotted yesterday. I tested them a bit, but it would be nice to get a beta build, so I could test it much better with dev-build of GeckoLib 3.0.0.