### PR TITLE
Fixed -() group not working

### DIFF
--- a/mclib/src/main/java/com/eliotlash/mclib/math/MathBuilder.java
+++ b/mclib/src/main/java/com/eliotlash/mclib/math/MathBuilder.java
@@ -461,7 +461,7 @@ public class MathBuilder
         /* Handle inversion of the value */
         if (first.equals("-"))
         {
-            return new Negative(this.parseSymbols(args));
+            return new Negative(new Group(this.parseSymbols(args)));
         }
 
         if (first.startsWith("-") && first.length() > 1)


### PR DESCRIPTION
This is copied from https://github.com/mchorse/mclib/commit/2b0cdb2d1da79ede6051d1d550b1018c40528fab 
Example of MoLang that breaks it: "-(math.sin(q.anim_time*90*8+90)*1)*20-5"